### PR TITLE
[fix] no-ssr

### DIFF
--- a/components/Beratung.vue
+++ b/components/Beratung.vue
@@ -1,19 +1,20 @@
 <template lang="pug">
-  section#beratungsstellen
-    div.inner
-      h2 Beratungsstellen
-      h3 Ruf uns an oder komm bei uns vorbei.
-    v-collapse-wrapper(v-for="bs, index in beratungsstellen" :key="index" :id="bs.id")
-      .title(v-collapse-toggle)
-        div.inner
-          h3 {{ bs.title }}
-          p.location {{ bs.location }}
-          p.tel {{ bs.tel }}
-      .content(v-collapse-content)
-        div.inner
-          a(v-bind:href="'http://' + bs.url" class="www" target="_blank") {{ bs.url }}
-          ul
-            li(v-for="item in bs.description") {{ item }}
+  no-ssr
+    section#beratungsstellen
+      div.inner
+        h2 Beratungsstellen
+        h3 Ruf uns an oder komm bei uns vorbei.
+      v-collapse-wrapper(v-for="bs, index in beratungsstellen" :key="index" :id="bs.id")
+          .title(v-collapse-toggle)
+            div.inner
+              h3 {{ bs.title }}
+                p.location {{ bs.location }}
+                p.tel {{ bs.tel }}
+          .content(v-collapse-content)
+            div.inner
+              a(v-bind:href="'http://' + bs.url" class="www" target="_blank") {{ bs.url }}
+              ul
+                li(v-for="item in bs.description") {{ item }}
 </template>
 
 <script>

--- a/components/Faq.vue
+++ b/components/Faq.vue
@@ -1,12 +1,13 @@
 <template lang="pug">
-  section#faq
-      div.inner
-        h2 Antworten auf Deine Fragen
-      v-collapse-wrapper(v-for="qa, index in faq" :key="index")
-        h3.title(v-collapse-toggle) {{ qa.q }}
-        .content(v-collapse-content) 
-          ul
-            li(v-for="item in qa.a") {{ item }}
+  no-ssr
+    section#faq
+        div.inner
+          h2 Antworten auf Deine Fragen
+        v-collapse-wrapper(v-for="qa, index in faq" :key="index")
+          h3.title(v-collapse-toggle) {{ qa.q }}
+          .content(v-collapse-content) 
+            ul
+              li(v-for="item in qa.a") {{ item }}
 </template>
 
 <script>

--- a/components/Slider.vue
+++ b/components/Slider.vue
@@ -1,18 +1,19 @@
 <template lang="pug">
   section#slider
-    flickity(ref="flickity" options="flickityOptions")
-      div.carousel-cell(v-for="v, index in videos" :key="index")
-        div.video-wrapper
-          iframe(:src="'https://www.youtube.com/embed/' + v.vid + '?showinfo=0'" :frameborder='0' :allowfullscreen='1')
+    no-ssr
+      flickity(ref="flickity" :options="flickityOptions")
+        div.carousel-cell(v-for="v, index in videos" :key="index")
+          div.video-wrapper
+            iframe(:src="'https://www.youtube.com/embed/' + v.vid + '?showinfo=0'" :frameborder='0' :allowfullscreen='1')
 
-        //div.youtube-player(:data-id="v.vid")
-        //img(:src="'images/' + sl.url" class="img-responsive")
-        div.text-wrapper  
-          h1.claim {{ v.claim }}
-          div.emoji
-          //div.logo
-          //img(:src="'images/' + sl.emoji_url" class="emojicon")
-          //img(:src="'images/logo.png'" class="logo")
+          //div.youtube-player(:data-id="v.vid")
+          //img(:src="'images/' + sl.url" class="img-responsive")
+          div.text-wrapper  
+            h1.claim {{ v.claim }}
+            div.emoji
+            //div.logo
+            //img(:src="'images/' + sl.emoji_url" class="emojicon")
+            //img(:src="'images/logo.png'" class="logo")
 
 </template>
 


### PR DESCRIPTION
@mmorger I found the problem. 

Since **Flickity** and the **accordion** libraries are adding markup to the DOM once the page loads, the virtual DOM generated by the server (in this case the local Node server running when you call `yarn dev`) looks different than the rendered DOM. 

So you have to tell those parts of the code not to render on the server by wrapping them in a `no-ssr` 
(no server-side-rendering) tag. 

Take a look at my Pull Request and see where I added the tag (3 files). 