### PR TITLE
Copy To Clipboard

### DIFF
--- a/components/Videos.vue
+++ b/components/Videos.vue
@@ -6,7 +6,7 @@
         .youtube-player(:data-id="v.vid" @click="vidClick($event)" :ref="v.vid")
         h1 {{ v.claim }}
         .share
-          button(:v-clipboard="'https://www.youtube.com/watch?v=' + v.vid", v-clipboard:success="clipboardSuccessHandler", v-clipboard:error="clipboardErrorHandler" class="button-share")
+          button(v-clipboard="'https://www.youtube.com/watch?v=' + v.vid", v-clipboard:success="clipboardSuccessHandler", v-clipboard:error="clipboardErrorHandler" class="button-share")
           
         
 </template>


### PR DESCRIPTION
Since the `v-clipboard` is a **directive**, rather than a **property**, you don't need the `:`