### PR TITLE
Safari iOS Videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist
 .vscode
 
 DS._Store
+.DS_Store

--- a/components/Slider.vue
+++ b/components/Slider.vue
@@ -13,6 +13,8 @@
 </template>
 
 <script>
+import MobileDetect from 'mobile-detect'
+
 export default {
   props: ["videos"],
 
@@ -23,7 +25,8 @@ export default {
         prevNextButtons: true,
         pageDots: true,
         wrapAround: true
-      }
+      },
+      isIOS: false
     }
   },
   methods: {
@@ -44,11 +47,16 @@ export default {
     }
   },
   mounted () {
-    this.$nextTick(() => {
-      this.$refs.flickity.on( 'select',  () => {
-        this.pauseVideos()
-      }) 
-    })
+    let md = new MobileDetect(window.navigator.userAgent)
+    if(md.mobile() === true && md.userAgent() === 'Safari') {
+      this.isIOS = true
+    } else {
+      this.$nextTick(() => {
+        this.$refs.flickity.on( 'select',  () => {
+          this.pauseVideos()
+        }) 
+      })
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "es6-promise": "^4.2.4",
+    "mobile-detect": "^1.4.2",
     "node-sass": "^4.9.0",
     "nuxt": "^1.0.0",
     "pug": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4104,6 +4104,10 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   dependencies:
     minimist "0.0.8"
 
+mobile-detect@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/mobile-detect/-/mobile-detect-1.4.2.tgz#d45ffff8d0a641aeecbc35a15d88149a34a18350"
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
• added `MobileDetect.js` to determine if the user is on Mobile Safari.
• if so, don't fire `pauseVideo()`

Tested on: 
- Mac Chrome
- iPhone X iOS Safari
- iPad Pro Safari
- Windows 10 IE11
- Android Chrome

@mmorger: make sure you run `yarn` before generating, to install the mobile detect package.