### PR TITLE
[fix] simply check for mobile

### DIFF
--- a/components/Slider.vue
+++ b/components/Slider.vue
@@ -26,7 +26,7 @@ export default {
         pageDots: true,
         wrapAround: true
       },
-      isIOS: false
+      isMobile: false
     }
   },
   methods: {
@@ -46,12 +46,11 @@ export default {
       const iframe = element.querySelector( 'iframe')
       iframe.contentWindow.postMessage('{"event":"command","func":"' + 'stopVideo' + '","args":""}', '*')
     }
-  }
-  /*
+  },
   mounted () {
     let md = new MobileDetect(window.navigator.userAgent)
-    if(md.mobile() === true && md.userAgent() === 'Safari') {
-      this.isIOS = true
+    if(md.mobile()) {
+      this.isMobile = true
     } else {
       this.$nextTick(() => {
         this.$refs.flickity.on( 'select',  () => {
@@ -60,7 +59,6 @@ export default {
       })
     }
   }
-  */
 }
 
 </script>


### PR DESCRIPTION
@mmorger I changed it to simply disable the `pauseVideo()` on any mobile device 🤞 

It seems to work on iOS Safari & Chrome. But I haven't tested it on Android. 